### PR TITLE
Fixed encoding issues for getting the ADFS identifier

### DIFF
--- a/diagnosticsModule/ADFSDiagnostics/Private/HelperUtilities.ps1
+++ b/diagnosticsModule/ADFSDiagnostics/Private/HelperUtilities.ps1
@@ -353,6 +353,7 @@ Function Get-ADFSIdentifier
     [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
     $cli = New-Object net.WebClient;
     $sslBinding = GetSslBinding
+    $cli.Encoding = [System.Text.Encoding]::UTF8
     $fedmetadataString = $cli.DownloadString("https://" + $sslBinding.HostNamePort + "/federationmetadata/2007-06/federationmetadata.xml")
     $fedmetadata = [xml]$fedmetadataString
     return $fedmetadata.EntityDescriptor.entityID


### PR DESCRIPTION
The encoding on the AD FS Metadata endpoint is not specified as a result the Web-Client assumes ISO 8859-1. This is an issue for servers in a different locale.
